### PR TITLE
feat: flatten CExpr tree into sequential CStatements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ SList(SNumber(42))                      — S-expression
   ↓ Transform
 LispCons(LispNumber(42), LispNil)       — AST
   ↓ Lowering
-CCall("make_cons", ...)                 — C expression
+CCall("make_cons", ...)                 — C expression tree
+  ↓ Flatten
+[Value("v0", ...), Return(CVar("v0"))]  — flat statements
   ↓ CodeGen
-"make_cons(make_int(42), make_nil())"   — C code
+"LispVal* v0 = make_int(42);\n..."      — C code
   ↓ GCC
 ./output/program                        — binary
 ```
@@ -43,6 +45,7 @@ src/main/scala/
       SExpr.scala               — S-expression types
       LispExpr.scala            — Lisp AST types
       CExpr.scala               — C expression types
+      CStatement.scala          — flat C statement types
     parse/
       Tokenizer.scala           — string → tokens
       Parser.scala              — tokens → SExpr
@@ -50,7 +53,8 @@ src/main/scala/
       Transform.scala           — SExpr → LispExpr
       Lowering.scala            — LispExpr → CExpr
     emit/
-      CodeGen.scala             — CExpr → C code string
+      Flatten.scala             — CExpr tree → flat CStatements
+      CodeGen.scala             — CStatements → C code string
       Runtime.scala             — runtime function names
     orchestration/
       Compiler.scala            — pipeline and file output

--- a/src/main/resources/template.c
+++ b/src/main/resources/template.c
@@ -1,7 +1,13 @@
 #include "runtime.h"
+#include <stdio.h>
+
+LispVal* lisp() {
+{{BODY}}
+}
 
 int main() {
-    LispVal* result = {{EXPR}};
+    LispVal* result = lisp();
     print_val(result);
+    printf("\n");
     return 0;
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -21,6 +21,7 @@ import scala.util.Using
 
   val cCode = Compiler.pipeline(lispCode)
   val template = Compiler.readResource("template.c")
-  val output = template.replace("{{EXPR}}", cCode)
+  val indented = "    " + cCode.replaceAll("\n", "\n    ")
+  val output = template.replace("{{BODY}}", indented)
 
   Compiler.initializeOutput(output)

--- a/src/main/scala/lisp/emit/CodeGen.scala
+++ b/src/main/scala/lisp/emit/CodeGen.scala
@@ -1,11 +1,24 @@
 package lisp.emit
 
-import lisp.types.CExpr
-import lisp.types.CExpr.{CCall, CNumber}
+import lisp.types.{CExpr, CStatement}
+import lisp.types.CExpr.{CCall, CNumber, CVar}
+import lisp.types.CStatement.*
 
 object CodeGen:
 
-  def apply(input: CExpr): String =
-    input match
-      case CNumber(value) => value.toString
-      case CCall(cmd, expr) => cmd + '(' + expr.map(apply).mkString(", ") + ')'
+  def apply(input: List[CStatement]): String =
+    input.map(emitStatement).mkString("\n")
+
+  private def emitStatement(stmt: CStatement): String =
+    stmt match
+      case Value(name, call) => s"LispVal* $name = ${emitCall(call)};"
+      case Return(expr)      => s"return ${emitExpr(expr)};"
+
+  private def emitCall(call: CCall): String =
+    call.name + "(" + call.args.map(emitExpr).mkString(", ") + ")"
+
+  private def emitExpr(expr: CExpr): String =
+    expr match
+      case CNumber(value)    => value.toString
+      case CVar(name)        => name
+      case CCall(name, args) => name + "(" + args.map(emitExpr).mkString(", ") + ")"

--- a/src/main/scala/lisp/emit/Flatten.scala
+++ b/src/main/scala/lisp/emit/Flatten.scala
@@ -1,0 +1,32 @@
+package lisp.emit
+
+import lisp.types.{CExpr, CStatement}
+import lisp.types.CExpr.*
+import lisp.types.CStatement.*
+
+import scala.collection.mutable
+
+object Flatten:
+
+  def apply(input: CExpr): List[CStatement] =
+
+    val result = mutable.ListBuffer[CStatement]()
+    var counter = 0
+
+    def flatten(input: CExpr): CExpr =
+      input match
+        case n: CNumber => n
+        case v: CVar    => v
+        case CCall(name, args) =>
+          val newArgs = args.map(flatten)
+          val varName = s"v$counter"
+          counter += 1
+          result += Value(varName, CCall(name, newArgs))
+          CVar(varName)
+
+    input match
+      case _: CCall =>
+        val lastVar = flatten(input)
+        result += Return(lastVar)
+        result.toList
+      case _ => throw new Exception("Expected CCall at top level")

--- a/src/main/scala/lisp/orchestration/Compiler.scala
+++ b/src/main/scala/lisp/orchestration/Compiler.scala
@@ -1,6 +1,6 @@
 package lisp.orchestration
 
-import lisp.emit.CodeGen
+import lisp.emit.{CodeGen, Flatten}
 import lisp.parse.{Parser, Tokenizer}
 import lisp.transform.{Lowering, Transform}
 
@@ -14,7 +14,8 @@ object Compiler:
     val sExpr = Parser(tokens)
     val lispExpr = Transform(sExpr)
     val cExpr = Lowering(lispExpr)
-    CodeGen(cExpr)
+    val statements = Flatten(cExpr)
+    CodeGen(statements)
 
   private def writeFile(dir: File, name: String, content: String): Unit =
     Using(PrintWriter(File(dir, name)))(_.write(content))

--- a/src/main/scala/lisp/types/CExpr.scala
+++ b/src/main/scala/lisp/types/CExpr.scala
@@ -3,3 +3,4 @@ package lisp.types
 enum CExpr:
   case CCall(name: String, args: List[CExpr])
   case CNumber(value: Int)
+  case CVar(name: String)

--- a/src/main/scala/lisp/types/CStatement.scala
+++ b/src/main/scala/lisp/types/CStatement.scala
@@ -1,0 +1,7 @@
+package lisp.types
+
+import lisp.types.CExpr.*
+
+enum CStatement:
+  case Return(expr: CExpr)
+  case Value(name: String, call: CCall)

--- a/src/test/scala/lisp/emit/CodeGenTest.scala
+++ b/src/test/scala/lisp/emit/CodeGenTest.scala
@@ -1,26 +1,35 @@
 package lisp.emit
 
 import lisp.types.CExpr.*
+import lisp.types.CStatement.*
 
 class CodeGenTest extends munit.FunSuite:
 
-  test("number"):
-    assertEquals(CodeGen(CNumber(42)), "42")
+  test("single value"):
+    val input = List(Value("v0", CCall("make_int", List(CNumber(42)))))
+    assertEquals(CodeGen(input), "LispVal* v0 = make_int(42);")
 
-  test("simple call"):
-    assertEquals(
-      CodeGen(CCall("make_int", List(CNumber(42)))),
-      "make_int(42)"
+  test("multiple values"):
+    val input = List(
+      Value("v0", CCall("make_int", List(CNumber(42)))),
+      Value("v1", CCall("make_nil", List())),
+      Value("v2", CCall("make_cons", List(CVar("v0"), CVar("v1"))))
     )
-
-  test("nested call"):
     assertEquals(
-      CodeGen(CCall("make_cons", List(
-        CCall("make_int", List(CNumber(1))),
-        CCall("make_nil", List())
-      ))),
-      "make_cons(make_int(1), make_nil())"
+      CodeGen(input),
+      "LispVal* v0 = make_int(42);\nLispVal* v1 = make_nil();\nLispVal* v2 = make_cons(v0, v1);"
     )
 
   test("empty args"):
-    assertEquals(CodeGen(CCall("make_nil", List())), "make_nil()")
+    val input = List(Value("v0", CCall("make_nil", List())))
+    assertEquals(CodeGen(input), "LispVal* v0 = make_nil();")
+
+  test("return"):
+    val input = List(
+      Value("v0", CCall("make_int", List(CNumber(42)))),
+      Return(CVar("v0"))
+    )
+    assertEquals(
+      CodeGen(input),
+      "LispVal* v0 = make_int(42);\nreturn v0;"
+    )

--- a/src/test/scala/lisp/emit/FlattenTest.scala
+++ b/src/test/scala/lisp/emit/FlattenTest.scala
@@ -1,0 +1,41 @@
+package lisp.emit
+
+import lisp.types.CExpr.*
+import lisp.types.CStatement.*
+
+class FlattenTest extends munit.FunSuite:
+
+  test("simple number call"):
+    val input = CCall("make_int", List(CNumber(42)))
+    assertEquals(
+      Flatten(input),
+      List(
+        Value("v0", CCall("make_int", List(CNumber(42)))),
+        Return(CVar("v0"))
+      )
+    )
+
+  test("nil call"):
+    val input = CCall("make_nil", List())
+    assertEquals(
+      Flatten(input),
+      List(
+        Value("v0", CCall("make_nil", List())),
+        Return(CVar("v0"))
+      )
+    )
+
+  test("nested cons"):
+    val input = CCall("make_cons", List(
+      CCall("make_int", List(CNumber(42))),
+      CCall("make_nil", List())
+    ))
+    assertEquals(
+      Flatten(input),
+      List(
+        Value("v0", CCall("make_int", List(CNumber(42)))),
+        Value("v1", CCall("make_nil", List())),
+        Value("v2", CCall("make_cons", List(CVar("v0"), CVar("v1")))),
+        Return(CVar("v2"))
+      )
+    )


### PR DESCRIPTION
## Summary
- New pipeline step: CExpr tree → flat List[CStatement] with temp variables
- CodeGen now emits one declaration per line
- Generated C code wrapped in `lisp()` function

Closes #3