### PR TITLE
refactor: rename CStatement → Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ src/main/scala/
       SExpr.scala               — S-expression types
       LispExpr.scala            — Lisp AST types
       CExpr.scala               — C expression types
-      CStatement.scala          — flat C statement types
+      Statement.scala           — flat C statement types
     parse/
       Tokenizer.scala           — string → tokens
       Parser.scala              — tokens → SExpr
@@ -53,8 +53,8 @@ src/main/scala/
       Transform.scala           — SExpr → LispExpr
       Lowering.scala            — LispExpr → CExpr
     emit/
-      Flatten.scala             — CExpr tree → flat CStatements
-      CodeGen.scala             — CStatements → C code string
+      Flatten.scala             — CExpr tree → flat Statements
+      CodeGen.scala             — Statements → C code string
       Runtime.scala             — runtime function names
     orchestration/
       Compiler.scala            — pipeline and file output

--- a/src/main/scala/lisp/emit/CodeGen.scala
+++ b/src/main/scala/lisp/emit/CodeGen.scala
@@ -1,15 +1,15 @@
 package lisp.emit
 
-import lisp.types.{CExpr, CStatement}
+import lisp.types.{CExpr, Statement}
 import lisp.types.CExpr.{CCall, CNumber, CVar}
-import lisp.types.CStatement.*
+import lisp.types.Statement.*
 
 object CodeGen:
 
-  def apply(input: List[CStatement]): String =
+  def apply(input: List[Statement]): String =
     input.map(emitStatement).mkString("\n")
 
-  private def emitStatement(stmt: CStatement): String =
+  private def emitStatement(stmt: Statement): String =
     stmt match
       case Value(name, call) => s"LispVal* $name = ${emitCall(call)};"
       case Return(expr)      => s"return ${emitExpr(expr)};"

--- a/src/main/scala/lisp/emit/Flatten.scala
+++ b/src/main/scala/lisp/emit/Flatten.scala
@@ -1,16 +1,16 @@
 package lisp.emit
 
-import lisp.types.{CExpr, CStatement}
+import lisp.types.{CExpr, Statement}
 import lisp.types.CExpr.*
-import lisp.types.CStatement.*
+import lisp.types.Statement.*
 
 import scala.collection.mutable
 
 object Flatten:
 
-  def apply(input: CExpr): List[CStatement] =
+  def apply(input: CExpr): List[Statement] =
 
-    val result = mutable.ListBuffer[CStatement]()
+    val result = mutable.ListBuffer[Statement]()
     var counter = 0
 
     def flatten(input: CExpr): CExpr =

--- a/src/main/scala/lisp/types/Statement.scala
+++ b/src/main/scala/lisp/types/Statement.scala
@@ -2,6 +2,6 @@ package lisp.types
 
 import lisp.types.CExpr.*
 
-enum CStatement:
+enum Statement:
   case Return(expr: CExpr)
   case Value(name: String, call: CCall)

--- a/src/test/scala/lisp/emit/CodeGenTest.scala
+++ b/src/test/scala/lisp/emit/CodeGenTest.scala
@@ -1,7 +1,7 @@
 package lisp.emit
 
 import lisp.types.CExpr.*
-import lisp.types.CStatement.*
+import lisp.types.Statement.*
 
 class CodeGenTest extends munit.FunSuite:
 

--- a/src/test/scala/lisp/emit/FlattenTest.scala
+++ b/src/test/scala/lisp/emit/FlattenTest.scala
@@ -1,7 +1,7 @@
 package lisp.emit
 
 import lisp.types.CExpr.*
-import lisp.types.CStatement.*
+import lisp.types.Statement.*
 
 class FlattenTest extends munit.FunSuite:
 


### PR DESCRIPTION
## Summary
- Rename `CStatement` → `Statement` for consistency with its variants (Value, Return)

Closes #2