### PR TITLE
CV: Scala pipeline + template для tagged LispVal

### DIFF
--- a/src/main/resources/template.c
+++ b/src/main/resources/template.c
@@ -1,12 +1,12 @@
 #include "runtime.h"
 #include <stdio.h>
 
-LispVal* lisp() {
+LispVal lisp(void) {
 {{BODY}}
 }
 
-int main() {
-    LispVal* result = lisp();
+int main(void) {
+    LispVal result = lisp();
     print_val(result);
     printf("\n");
     return 0;

--- a/src/main/scala/lisp/emit/CodeGen.scala
+++ b/src/main/scala/lisp/emit/CodeGen.scala
@@ -11,7 +11,7 @@ object CodeGen:
 
   private def emitStatement(stmt: Statement): String =
     stmt match
-      case Value(name, call) => s"LispVal* $name = ${emitCall(call)};"
+      case Value(name, call) => s"LispVal $name = ${emitCall(call)};"
       case Return(expr)      => s"return ${emitExpr(expr)};"
 
   private def emitCall(call: CCall): String =

--- a/src/main/scala/lisp/orchestration/Compiler.scala
+++ b/src/main/scala/lisp/orchestration/Compiler.scala
@@ -26,8 +26,10 @@ object Compiler:
   def initializeOutput(output: String): Unit =
     val outDir = File("output")
     if (!outDir.exists()) outDir.mkdirs()
+    val tagsH = readResource("tags.h")
     val runtimeH = readResource("runtime.h")
     val runtimeC = readResource("runtime.c")
+    writeFile(outDir, "tags.h", tagsH)
     writeFile(outDir, "runtime.h", runtimeH)
     writeFile(outDir, "runtime.c", runtimeC)
     writeFile(outDir, "output.c", output)

--- a/src/test/scala/lisp/emit/CodeGenTest.scala
+++ b/src/test/scala/lisp/emit/CodeGenTest.scala
@@ -7,7 +7,7 @@ class CodeGenTest extends munit.FunSuite:
 
   test("single value"):
     val input = List(Value("v0", CCall("make_int", List(CNumber(42)))))
-    assertEquals(CodeGen(input), "LispVal* v0 = make_int(42);")
+    assertEquals(CodeGen(input), "LispVal v0 = make_int(42);")
 
   test("multiple values"):
     val input = List(
@@ -17,12 +17,12 @@ class CodeGenTest extends munit.FunSuite:
     )
     assertEquals(
       CodeGen(input),
-      "LispVal* v0 = make_int(42);\nLispVal* v1 = make_nil();\nLispVal* v2 = make_cons(v0, v1);"
+      "LispVal v0 = make_int(42);\nLispVal v1 = make_nil();\nLispVal v2 = make_cons(v0, v1);"
     )
 
   test("empty args"):
     val input = List(Value("v0", CCall("make_nil", List())))
-    assertEquals(CodeGen(input), "LispVal* v0 = make_nil();")
+    assertEquals(CodeGen(input), "LispVal v0 = make_nil();")
 
   test("return"):
     val input = List(
@@ -31,5 +31,5 @@ class CodeGenTest extends munit.FunSuite:
     )
     assertEquals(
       CodeGen(input),
-      "LispVal* v0 = make_int(42);\nreturn v0;"
+      "LispVal v0 = make_int(42);\nreturn v0;"
     )


### PR DESCRIPTION
## Summary
- template.c, CodeGen, CodeGenTest: LispVal* → LispVal
- Compiler: копирует tags.h в output
- E2E: `just run "(42)"` → `(42)`

Closes #22, closes #23, closes #24