### PR TITLE
BE: bare expressions через -e флаг

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,13 +21,13 @@ help:
 
 # Lisp → C → GCC
 [group('build')]
-build input:
-    {{sbt}} "run {{input}}"
+build +args:
+    {{sbt}} "run {{args}}"
     gcc -Ioutput output/output.c output/runtime.c -o output/program
 
 # Build and run
 [group('run')]
-run input: (build input)
+run +args: (build args)
     ./output/program
 
 # Run all examples

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -6,15 +6,17 @@ import scala.util.Using
 
 @main def lisp2c(args: String*): Unit =
   if args.isEmpty then
-    println("Usage: lisp2c <file|expression>")
+    println("Usage: lisp2c <file.lisp | -e expression>")
     sys.exit(1)
-  val input = args.mkString(" ").trim
-  val file = File(input)
-  val lispCode =
-    if input.startsWith("(") && input.endsWith(")") then input
-    else
+  val argList = args.toList
+  val lispCode = argList match
+    case "-e" :: rest if rest.nonEmpty =>
+      rest.mkString(" ").trim
+    case _ =>
+      val path = argList.mkString(" ").trim
+      val file = File(path)
       if !file.exists() then
-        println(s"File not found: $input")
+        println(s"File not found: $path")
         sys.exit(1)
       Using(Source.fromFile(file))(_.mkString).get
 


### PR DESCRIPTION
Флаг `-e` для выражений, без флага — файл. Как в Python/Node/Racket.

- `just run -e "(+ 1 2)"` → выражение
- `just run -e 42` → bare expression  
- `just run file.lisp` → файл

Closes #26