### PR TITLE
chore: code style — lowercase errors, imports via scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,7 +1,16 @@
 rules = [
   RemoveUnused,
-  DisableSyntax
+  DisableSyntax,
+  OrganizeImports
 ]
+
+OrganizeImports.groups = [
+  "re:lisp\\..*",
+  "*",
+  "re:(java|scala)\\..*"
+]
+OrganizeImports.groupedImports = Keep
+OrganizeImports.importSelectorsOrder = Ascii
 
 DisableSyntax.noVars = false
 DisableSyntax.noReturns = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,9 +9,4 @@ newlines.topLevelStatementBlankLines = [
 ]
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = true
-rewrite.rules = [Imports]
-rewrite.imports.sort = scalastyle
-rewrite.imports.groups = [
-  ["lisp\\..*"],
-  ["java\\..*", "scala\\..*"]
-]
+rewrite.rules = []

--- a/src/main/scala/lisp/emit/CodeGen.scala
+++ b/src/main/scala/lisp/emit/CodeGen.scala
@@ -36,4 +36,4 @@ object CodeGen:
       case CStringLit(s)     => s"\"$s\""
       case CVar(name)        => name
       case CCall(name, args) => name + "(" + args.map(emitExpr).mkString(", ") + ")"
-      case CIf(_, _, _)      => throw new Exception("CIf must be flattened before codegen")
+      case CIf(_, _, _)      => throw new Exception("CIf must be flattened before CodeGen")

--- a/src/main/scala/lisp/emit/Flatten.scala
+++ b/src/main/scala/lisp/emit/Flatten.scala
@@ -34,23 +34,23 @@ object Flatten:
 
   private def flatten(input: CExpr, ctx: FlattenCtx): CExpr =
     input match
-      case n: CNumber => n
-      case v: CVar    => v
+      case n: CNumber    => n
+      case v: CVar       => v
       case s: CStringLit => s
       case CIf(cond, thenBranch, elseBranch) =>
         val condVar = flatten(cond, ctx) match
           case CVar(name) => name
-          case _          => throw new Exception("Flatten: cond must resolve to a var")
+          case _          => throw new Exception("flatten: cond must resolve to a var")
 
         val thenCtx = ctx.nested()
         val thenVar = flatten(thenBranch, thenCtx) match
           case CVar(name) => name
-          case _          => throw new Exception("Flatten: then must resolve to a var")
+          case _          => throw new Exception("flatten: then must resolve to a var")
 
         val elseCtx = ctx.nested()
         val elseVar = flatten(elseBranch, elseCtx) match
           case CVar(name) => name
-          case _          => throw new Exception("Flatten: else must resolve to a var")
+          case _          => throw new Exception("flatten: else must resolve to a var")
 
         val resultVar = ctx.freshVar()
         ctx.emit(

--- a/src/main/scala/lisp/parse/Parser.scala
+++ b/src/main/scala/lisp/parse/Parser.scala
@@ -14,8 +14,8 @@ object Parser:
 
   private def parse(tokens: List[String]): (SExpr, List[String]) =
     tokens match
-      case Nil         => throw new Exception("Empty input")
-      case ")" :: _    => throw new Exception("Unexpected )")
+      case Nil         => throw new Exception("empty input")
+      case ")" :: _    => throw new Exception("unexpected )")
       case "(" :: rest => parseList(Nil, rest)
       case x :: rest =>
         x match
@@ -29,7 +29,7 @@ object Parser:
   @tailrec
   private def parseList(acc: List[SExpr], tokens: List[String]): (SExpr, List[String]) =
     tokens match
-      case Nil         => throw new Exception("Unexpected end of list")
+      case Nil         => throw new Exception("unexpected end of list")
       case ")" :: rest => (SList(acc.reverse), rest)
       case _ =>
         val (expr, remaining) = parse(tokens)

--- a/src/main/scala/lisp/transform/Lowering.scala
+++ b/src/main/scala/lisp/transform/Lowering.scala
@@ -25,18 +25,18 @@ object Lowering:
 
   private def lowerQuote(input: LispExpr): CExpr =
     input match
-      case LispNil => CVar(lispNil)
-      case LispNumber(n) => CCall(makeInt, List(CNumber(n)))
-      case LispBool(true) => CVar(lispTrue)
-      case LispBool(false) => CVar(lispFalse)
-      case LispCons(a, b) => CCall(makeCons, List(lowerQuote(a), lowerQuote(b)))
+      case LispNil          => CVar(lispNil)
+      case LispNumber(n)    => CCall(makeInt, List(CNumber(n)))
+      case LispBool(true)   => CVar(lispTrue)
+      case LispBool(false)  => CVar(lispFalse)
+      case LispCons(a, b)   => CCall(makeCons, List(lowerQuote(a), lowerQuote(b)))
       case LispSymbol(name) => CCall(makeSymbol, List(CStringLit(name)))
-      case _ => throw new Exception(s"unsupported expression $input")
+      case _                => throw new Exception(s"unsupported expression $input")
 
   private def lowerFunc(symbol: String, args: List[LispExpr]): CExpr =
     functions.get(symbol) match
       case Some((func, arity)) if args.length == arity => CCall(func, args.map(lower))
-      case Some(_)                                     => throw new Exception(s"Wrong arity for $symbol")
+      case Some(_)                                     => throw new Exception(s"wrong arity for $symbol")
       case None => throw new Exception(s"unsupported function $symbol with ${args.length} args")
 
   private val functions = Map(
@@ -51,5 +51,5 @@ object Lowering:
     "<" -> (lispLt, 2),
     ">" -> (lispGt, 2),
     "car" -> (lispCar, 1),
-    "cdr" -> (lispCdr, 1),
+    "cdr" -> (lispCdr, 1)
   )

--- a/src/main/scala/lisp/transform/Transform.scala
+++ b/src/main/scala/lisp/transform/Transform.scala
@@ -17,11 +17,12 @@ object Transform:
       case SSymbol("nil") => LispNil
       case SSymbol(value) => LispSymbol(value)
       case SList(Nil)     => LispNil
-      case SList(SSymbol("if") :: cond :: thenBranch :: elseBranch :: Nil) => LispIf(transform(cond), transform(thenBranch), transform(elseBranch))
+      case SList(SSymbol("if") :: cond :: thenBranch :: elseBranch :: Nil) =>
+        LispIf(transform(cond), transform(thenBranch), transform(elseBranch))
       case SList(SSymbol("if") :: _) => throw new Exception("if requires exactly 3 arguments: condition, then, else")
       case SList(SSymbol("quote") :: body :: Nil) => LispQuote(transformQuoted(body))
-      case SList(SSymbol("quote") :: _) => throw new Exception("quote requires exactly 1 argument")
-      case SList(head :: args) => LispApply(transform(head), args.map(transform))
+      case SList(SSymbol("quote") :: _)           => throw new Exception("quote requires exactly 1 argument")
+      case SList(head :: args)                    => LispApply(transform(head), args.map(transform))
 
   private def transformQuoted(input: SExpr): LispExpr =
     input match

--- a/src/test/scala/lisp/transform/LoweringTest.scala
+++ b/src/test/scala/lisp/transform/LoweringTest.scala
@@ -38,29 +38,38 @@ class LoweringTest extends munit.FunSuite:
   test("quote cons pair"):
     assertEquals(
       Lowering(LispQuote(LispCons(LispNumber(1), LispNumber(2)))),
-      CCall("make_cons", List(
-        CCall("make_int", List(CNumber(1))),
-        CCall("make_int", List(CNumber(2)))
-      ))
+      CCall(
+        "make_cons",
+        List(
+          CCall("make_int", List(CNumber(1))),
+          CCall("make_int", List(CNumber(2)))
+        )
+      )
     )
 
   test("quote list (1 2 3)"):
-    val input = LispQuote(LispCons(
-      LispNumber(1),
-      LispCons(LispNumber(2),
-        LispCons(LispNumber(3), LispNil))))
+    val input = LispQuote(LispCons(LispNumber(1), LispCons(LispNumber(2), LispCons(LispNumber(3), LispNil))))
     assertEquals(
       Lowering(input),
-      CCall("make_cons", List(
-        CCall("make_int", List(CNumber(1))),
-        CCall("make_cons", List(
-          CCall("make_int", List(CNumber(2))),
-          CCall("make_cons", List(
-            CCall("make_int", List(CNumber(3))),
-            CVar("LISP_NIL")
-          ))
-        ))
-      ))
+      CCall(
+        "make_cons",
+        List(
+          CCall("make_int", List(CNumber(1))),
+          CCall(
+            "make_cons",
+            List(
+              CCall("make_int", List(CNumber(2))),
+              CCall(
+                "make_cons",
+                List(
+                  CCall("make_int", List(CNumber(3))),
+                  CVar("LISP_NIL")
+                )
+              )
+            )
+          )
+        )
+      )
     )
 
   test("cons pair"):

--- a/src/test/scala/lisp/transform/TransformTest.scala
+++ b/src/test/scala/lisp/transform/TransformTest.scala
@@ -126,8 +126,11 @@ class TransformTest extends munit.FunSuite:
     val input = SList(List(SSymbol("*"), SNumber(3), SList(List(SSymbol("+"), SNumber(1), SNumber(2)))))
     assertEquals(
       Transform(input),
-      LispApply(LispSymbol("*"), List(
-        LispNumber(3),
-        LispApply(LispSymbol("+"), List(LispNumber(1), LispNumber(2)))
-      ))
+      LispApply(
+        LispSymbol("*"),
+        List(
+          LispNumber(3),
+          LispApply(LispSymbol("+"), List(LispNumber(1), LispNumber(2)))
+        )
+      )
     )


### PR DESCRIPTION
Ошибки с маленькой буквы (кроме имён типов). Импорты перенесены с scalafmt на scalafix OrganizeImports — порядок групп стабилен.