### PR TITLE
feat: quote shorthand ('x)

### DIFF
--- a/src/main/scala/lisp/parse/Parser.scala
+++ b/src/main/scala/lisp/parse/Parser.scala
@@ -24,6 +24,9 @@ object Parser:
       case Nil         => throw new Exception("empty input")
       case ")" :: _    => throw new Exception("unexpected )")
       case "(" :: rest => parseList(Nil, rest)
+      case "'" :: rest =>
+        val (expr, remaining) = parse(rest)
+        (SList(List(SSymbol("quote"), expr)), remaining)
       case x :: rest =>
         x match
           case "#t" => (SBool(true), rest)

--- a/src/main/scala/lisp/parse/Tokenizer.scala
+++ b/src/main/scala/lisp/parse/Tokenizer.scala
@@ -9,8 +9,9 @@ object Tokenizer:
   def apply(input: String, current: String = ""): List[String] =
     val prefix = if current.isEmpty then List() else List(current)
     input.toList match
-      case Nil         => prefix
-      case '(' :: rest => prefix ++ List("(") ++ apply(rest.mkString)
-      case ')' :: rest => prefix ++ List(")") ++ apply(rest.mkString)
-      case ' ' :: rest => prefix ++ apply(rest.mkString)
-      case c :: rest   => apply(rest.mkString, current + c)
+      case Nil          => prefix
+      case '(' :: rest  => prefix ++ List("(") ++ apply(rest.mkString)
+      case ')' :: rest  => prefix ++ List(")") ++ apply(rest.mkString)
+      case ' ' :: rest  => prefix ++ apply(rest.mkString)
+      case '\'' :: rest => prefix ++ List("'") ++ apply(rest.mkString)
+      case c :: rest    => apply(rest.mkString, current + c)

--- a/src/test/scala/lisp/parse/ParserTest.scala
+++ b/src/test/scala/lisp/parse/ParserTest.scala
@@ -64,3 +64,18 @@ class ParserTest extends munit.FunSuite:
   test("parseAll single form"):
     val tokens = Tokenizer("(42)")
     assertEquals(Parser.parseAll(tokens), List(SList(List(SNumber(42)))))
+
+  test("quote shorthand symbol"):
+    val tokens = Tokenizer("'foo")
+    assertEquals(Parser(tokens), SList(List(SSymbol("quote"), SSymbol("foo"))))
+
+  test("quote shorthand list"):
+    val tokens = Tokenizer("'(1 2 3)")
+    assertEquals(
+      Parser(tokens),
+      SList(List(SSymbol("quote"), SList(List(SNumber(1), SNumber(2), SNumber(3)))))
+    )
+
+  test("quote shorthand empty list"):
+    val tokens = Tokenizer("'()")
+    assertEquals(Parser(tokens), SList(List(SSymbol("quote"), SList(List()))))

--- a/src/test/scala/lisp/parse/TokenizerTest.scala
+++ b/src/test/scala/lisp/parse/TokenizerTest.scala
@@ -22,3 +22,9 @@ class TokenizerTest extends munit.FunSuite:
 
   test("quote expression"):
     assertEquals(Tokenizer("(quote foo)"), List("(", "quote", "foo", ")"))
+
+  test("quote shorthand"):
+    assertEquals(Tokenizer("'foo"), List("'", "foo"))
+
+  test("quote shorthand list"):
+    assertEquals(Tokenizer("'(1 2 3)"), List("'", "(", "1", "2", "3", ")"))


### PR DESCRIPTION
Синтаксический сахар `'x` → `(quote x)` в Tokenizer и Parser.

Closes #52